### PR TITLE
Update query building for Rails 6.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Update internal query building for Rails 6.1 compatibility. ([@zokioki][])
+
 ## 0.3.0 (2019-28-01)
 
 - Rename `#value` method to `#overlap_values`.

--- a/lib/pgrel/active_record/store_chain.rb
+++ b/lib/pgrel/active_record/store_chain.rb
@@ -144,6 +144,14 @@ module ActiveRecord
       def build_or_contains(k, vals)
         vals.map { |v| contains_clause(k => v) }.join(' or ')
       end
+
+      def build_where_clause(opts)
+        if ActiveRecord.version.release >= Gem::Version.new("6.1.0")
+          @scope.send(:build_where_clause, opts)
+        else
+          @scope.send(:where_clause_factory).build(opts, [])
+        end
+      end
     end
 
     # Base class for key-value types of stores (hstore, jsonb)
@@ -222,14 +230,6 @@ module ActiveRecord
           end
           @scope.where_values += where_value
           @scope
-        end
-      end
-
-      def build_where_clause(opts)
-        if ActiveRecord.version.release >= Gem::Version.new("6.1.0")
-          @scope.send(:build_where_clause, opts)
-        else
-          @scope.send(:where_clause_factory).build(opts, [])
         end
       end
     end

--- a/lib/pgrel/active_record/store_chain.rb
+++ b/lib/pgrel/active_record/store_chain.rb
@@ -211,7 +211,7 @@ module ActiveRecord
 
           # Converting `HomogenousIn` node to `In` type allows us to set its `left`
           # to sql literal as with other node types (`HomogenousIn` does not support this).
-          if where_clause_ast.is_a?(Arel::Nodes::HomogeneousIn)
+          if defined?(Arel::Nodes::HomogeneousIn) && where_clause_ast.is_a?(Arel::Nodes::HomogeneousIn)
             where_clause_ast = Arel::Nodes::In.new(where_clause_ast.left, where_clause_ast.right)
           end
 

--- a/lib/pgrel/active_record/store_chain.rb
+++ b/lib/pgrel/active_record/store_chain.rb
@@ -225,8 +225,6 @@ module ActiveRecord
         end
       end
 
-      private
-
       def build_where_clause(opts)
         if ActiveRecord.version.release >= Gem::Version.new("6.1.0")
           @scope.send(:build_where_clause, opts)

--- a/lib/pgrel/active_record/store_chain.rb
+++ b/lib/pgrel/active_record/store_chain.rb
@@ -93,7 +93,7 @@ module ActiveRecord
         protected
 
         def update_scope(*opts)
-          where_clause = @scope.send(:where_clause_factory).build(opts, {})
+          where_clause = build_where_clause(opts)
           @scope.where_clause += @inverted ? where_clause.invert : where_clause
           @scope
         end
@@ -198,7 +198,7 @@ module ActiveRecord
 
       if ActiveRecord.version.release >= Gem::Version.new("5")
         def where_with_prefix(prefix, opts)
-          where_clause = @scope.send(:where_clause_factory).build(opts, [])
+          where_clause = build_where_clause(opts)
           predicates = where_clause.ast.children.map do |rel|
             rel.left = to_sql_literal(prefix, rel.left)
             rel
@@ -222,6 +222,16 @@ module ActiveRecord
           end
           @scope.where_values += where_value
           @scope
+        end
+      end
+
+      private
+
+      def build_where_clause(opts)
+        if ActiveRecord.version.release >= Gem::Version.new("6.1.0")
+          @scope.send(:build_where_clause, opts)
+        else
+          @scope.send(:where_clause_factory).build(opts, [])
         end
       end
     end

--- a/lib/pgrel/active_record/store_chain.rb
+++ b/lib/pgrel/active_record/store_chain.rb
@@ -209,6 +209,12 @@ module ActiveRecord
           where_clause = build_where_clause(opts)
           where_clause_ast = where_clause.ast
 
+          # Converting `HomogenousIn` node to `In` type allows us to set its `left`
+          # to sql literal as with other node types (`HomogenousIn` does not support this).
+          if where_clause_ast.is_a?(Arel::Nodes::HomogeneousIn)
+            where_clause_ast = Arel::Nodes::In.new(where_clause_ast.left, where_clause_ast.right)
+          end
+
           predicates = if where_clause_ast.is_a?(Arel::Nodes::And)
                          where_clause.ast.children.map do |rel|
                            rel.left = to_sql_literal(prefix, rel.left)


### PR DESCRIPTION
As of rails 6.1, the `where_clause_factory` method has been [removed](https://github.com/rails/rails/commit/550ce69f8adcd19542453ae03ac837a9ac8adf4b)
in favor of `build_where_clause` - this updates the logic to reflect it.

Addresses https://github.com/palkan/pgrel/issues/13.